### PR TITLE
fix: allow handlers with keyword arguments

### DIFF
--- a/aws_lambda_env_modeler/modeler.py
+++ b/aws_lambda_env_modeler/modeler.py
@@ -35,9 +35,9 @@ def init_environment_variables(model: Type[Model]):
     def decorator(lambda_handler_function: Callable):
 
         @wraps(lambda_handler_function)
-        def wrapper(event: Dict[str, Any], context):
+        def wrapper(event: Dict[str, Any], context, **kwargs):
             __parse_model(model)
-            return lambda_handler_function(event, context)
+            return lambda_handler_function(event, context, **kwargs)
 
         return wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_lambda_env_modeler"
-version = "1.0.3"
+version = "1.0.5"
 description = "AWS-Lambda-Env-Modeler is a Python library designed to simplify the process of managing and validating environment variables in your AWS Lambda functions."
 authors = ["Ran Isenberg"]
 classifiers=[

--- a/tests/unit/test_env_vars_parser.py
+++ b/tests/unit/test_env_vars_parser.py
@@ -17,7 +17,6 @@ class MySchema(BaseModel):
 
 
 def test_handler_missing_env_var():
-
     @init_environment_variables(model=MySchema)
     def my_handler1(event, context) -> Dict[str, Any]:
         return {}
@@ -26,9 +25,15 @@ def test_handler_missing_env_var():
         my_handler1({}, None)
 
 
-@mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'fakeapi'})
+@mock.patch.dict(
+    os.environ,
+    {
+        'POWERTOOLS_SERVICE_NAME': SERVICE_NAME,
+        'LOG_LEVEL': 'DEBUG',
+        'REST_API': 'fakeapi',
+    },
+)
 def test_handler_invalid_env_var_value():
-
     @init_environment_variables(model=MySchema)
     def my_handler2(event, context) -> Dict[str, Any]:
         return {}
@@ -37,9 +42,15 @@ def test_handler_invalid_env_var_value():
         my_handler2({}, None)
 
 
-@mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'https://www.ranthebuilder.cloud/api'})
+@mock.patch.dict(
+    os.environ,
+    {
+        'POWERTOOLS_SERVICE_NAME': SERVICE_NAME,
+        'LOG_LEVEL': 'DEBUG',
+        'REST_API': 'https://www.ranthebuilder.cloud/api',
+    },
+)
 def test_handler_schema_ok():
-
     @init_environment_variables(model=MySchema)
     def my_handler(event, context) -> Dict[str, Any]:
         env_vars: MySchema = get_environment_variables(model=MySchema)
@@ -49,3 +60,17 @@ def test_handler_schema_ok():
         return {}
 
     my_handler({}, None)
+
+
+def test_extended_handler_schema_ok(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('POWERTOOLS_SERVICE_NAME', SERVICE_NAME)
+    monkeypatch.setenv('LOG_LEVEL', 'DEBUG')
+    monkeypatch.setenv('REST_API', 'https://www.ranthebuilder.cloud/api')
+
+    endpoint = os.environ['REST_API']
+
+    @init_environment_variables(model=MySchema)
+    def my_handler(event, context, endpoint=None):
+        return endpoint
+
+    assert my_handler({}, None, endpoint=endpoint) == endpoint

--- a/tests/unit/test_env_vars_parser.py
+++ b/tests/unit/test_env_vars_parser.py
@@ -25,14 +25,7 @@ def test_handler_missing_env_var():
         my_handler1({}, None)
 
 
-@mock.patch.dict(
-    os.environ,
-    {
-        'POWERTOOLS_SERVICE_NAME': SERVICE_NAME,
-        'LOG_LEVEL': 'DEBUG',
-        'REST_API': 'fakeapi',
-    },
-)
+@mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'fakeapi'})
 def test_handler_invalid_env_var_value():
     @init_environment_variables(model=MySchema)
     def my_handler2(event, context) -> Dict[str, Any]:
@@ -42,14 +35,7 @@ def test_handler_invalid_env_var_value():
         my_handler2({}, None)
 
 
-@mock.patch.dict(
-    os.environ,
-    {
-        'POWERTOOLS_SERVICE_NAME': SERVICE_NAME,
-        'LOG_LEVEL': 'DEBUG',
-        'REST_API': 'https://www.ranthebuilder.cloud/api',
-    },
-)
+@mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'https://www.ranthebuilder.cloud/api'})
 def test_handler_schema_ok():
     @init_environment_variables(model=MySchema)
     def my_handler(event, context) -> Dict[str, Any]:

--- a/tests/unit/test_env_vars_parser.py
+++ b/tests/unit/test_env_vars_parser.py
@@ -17,6 +17,7 @@ class MySchema(BaseModel):
 
 
 def test_handler_missing_env_var():
+
     @init_environment_variables(model=MySchema)
     def my_handler1(event, context) -> Dict[str, Any]:
         return {}
@@ -27,6 +28,7 @@ def test_handler_missing_env_var():
 
 @mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'fakeapi'})
 def test_handler_invalid_env_var_value():
+
     @init_environment_variables(model=MySchema)
     def my_handler2(event, context) -> Dict[str, Any]:
         return {}
@@ -37,6 +39,7 @@ def test_handler_invalid_env_var_value():
 
 @mock.patch.dict(os.environ, {'POWERTOOLS_SERVICE_NAME': SERVICE_NAME, 'LOG_LEVEL': 'DEBUG', 'REST_API': 'https://www.ranthebuilder.cloud/api'})
 def test_handler_schema_ok():
+
     @init_environment_variables(model=MySchema)
     def my_handler(event, context) -> Dict[str, Any]:
         env_vars: MySchema = get_environment_variables(model=MySchema)


### PR DESCRIPTION
closes #46

This change preserves keyword arguments added to the Lambda Handler function signature, thus no longer raising TypeError when calling a decorated function.